### PR TITLE
Add release scripts

### DIFF
--- a/.github/workflows/complete-release.yml
+++ b/.github/workflows/complete-release.yml
@@ -1,0 +1,39 @@
+name: Complete Release
+
+on:
+  pull_request:
+    types:
+    - closed
+    branches:
+    - master
+
+jobs:
+  tag-and-release:
+    # Run only after release PR branch is merged
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'develop')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Get Tag Name
+      id: get_tag_name
+      run: echo "tag_name=v$(cat pubspec.yaml | yq -r '.version')" >> $GITHUB_OUTPUT
+  
+    - name: Create Tag
+      id: create_tag
+      uses: rickstaa/action-create-tag@v1
+      with: 
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ steps.get_tag_name.outputs.tag_name }}
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.get_tag_name.outputs.tag_name }}
+        name: ${{ steps.get_tag_name.outputs.tag_name }}
+        draft: true
+        prerelease: false
+        body_path: .scripts/changes.md

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -1,0 +1,50 @@
+name: Update Versions
+
+on:
+  workflow_dispatch:
+    inputs:
+      distribution-version:
+        description: 'Distribution Version of the release'
+        required: true
+        type: string
+      ios-version:
+        description: 'Version of the iOS SDK to incorporate'
+        required: true
+        type: string
+      android-version:
+          description: 'Version of the Android SDK to incorporate'
+          required: true
+          type: string
+        
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: develop
+
+      - name: Update distribution version plus any incidental copies
+        run: .scripts/update_distribution_version.sh "${{ inputs.distribution-version }}"
+      
+      - name: Update ApptentiveKit iOS dependency
+        run: .scripts/update_ios_version.sh ios/apptentive_flutter.podspec "${{ inputs.ios-version }}"
+
+      - name: Update ApptentiveKit Android dependency
+        run: .scripts/update_android_version.sh android/build.gradle "${{ inputs.android-version }}"
+      
+      - name: Update CHANGELOG.md
+        id: changelog
+        run: |
+           .scripts/add_changelog_entry.sh "${{ inputs.distribution-version }}" "${{ inputs.android-version }}" "${{ inputs.ios-version }}" \
+           > .scripts/changes.md
+  
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "Update for ${{ inputs.distribution-version }}"
+          committer: "Alchemer Mobile Team <sdks@apptentive.com>"
+          branch: "updates/${{ inputs.distribution-version }}"
+          base: develop
+          title: "Update for v${{ inputs.distribution-version }}"
+          body-path: .scripts/changes.md

--- a/.scripts/add_changelog_entry.sh
+++ b/.scripts/add_changelog_entry.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Fail on first error.
+set -e
+
+# Check for correct number of arguments.
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <new.distribution.version> <new.ios.version> <new.android.version>"
+    exit 1  # Exit the script with an error status
+fi
+
+# Create and change to a temporary directory.
+mkdir CHANGELOG-update
+cd CHANGELOG-update
+
+# Split the CHANGELOG.md file into multiple parts with a pattern matching 
+# the start of a new version entry.
+# The filenames with be 'xaa', 'xab', 'xac', etc.
+cat ../CHANGELOG.md | csplit -s - '/^# 20/' {1}
+
+# Create the new version entry's heading and add it to a file whose name
+# is alphabetically after the CHANGELOG's preamble.
+echo "# $(date -Idate) - v$1" > xx00a
+echo "" >> xx00a
+
+# Add the new version entry's body a file whose name is alphabetically 
+# after the heading.
+echo "- Apptentive Android SDK: $2" > xx00b
+echo "- Apptentive iOS SDK: $3" >> xx00b
+echo "" >> xx00b
+
+# Copy the new entry to print out later.
+NEW_ENTRY=$(cat xx00b)
+
+# Reassebmble the parts of the changelog into a local copy.
+cat $(ls -1 | sort) > foo.md
+
+# Move the local copy of the changelog to the original location.
+mv foo.md ../CHANGELOG.md
+
+# Clean up the temporary directory.
+rm x*
+cd ..
+rmdir CHANGELOG-update
+
+echo "$NEW_ENTRY"

--- a/.scripts/changes.md
+++ b/.scripts/changes.md
@@ -1,0 +1,2 @@
+- Apptentive Android SDK: 6.5.0
+- Apptentive iOS SDK: 6.5.0

--- a/.scripts/update_android_version.sh
+++ b/.scripts/update_android_version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Fail on first error.
+set -e
+
+# Check for correct number of arguments.
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <build.gradle_filename> <new.apptentive-kit-android.version>"
+    exit 1
+fi
+
+dependency_name="com.apptentive:apptentive-kit-android"
+new_version="$2"
+build_gradle_file="$1"
+
+# Check if the build.gradle file exists
+if [ ! -f "$build_gradle_file" ]; then
+    echo "Error: $build_gradle_file does not exist."
+    exit 1
+fi
+
+# Use sed to update the version in the podspec file
+sed -i "s/implementation '$dependency_name:[^']*'/implementation '$dependency_name:$new_version'/" "$build_gradle_file"
+
+echo "Updated $dependency_name to version $new_version in $build_gradle_file."

--- a/.scripts/update_distribution_version.sh
+++ b/.scripts/update_distribution_version.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# This script should update any incidental copies of the 
+# "single source of truth" version, e.g. in package.json.
+# It will be different for each project.
+
+# Fail on first error.
+set -e
+
+# Check for correct number of arguments.
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <new.distribution.version>"
+    exit 1
+fi
+
+new_version="$1"
+pubspec_file="pubspec.yaml"
+
+# Check if the podspec file exists
+if [ ! -f "$pubspec_file" ]; then
+    echo "Error: $pubspec_file does not exist."
+    exit 1
+fi
+
+version_script=".version=\"$new_version\""
+yq e -i $version_script "$pubspec_file"
+
+echo "Updated version to $new_version in $pubspec_file."
+
+podspec_file="ios/apptentive_flutter.podspec"
+
+# Check if the podspec file exists
+if [ ! -f "$podspec_file" ]; then
+    echo "Error: $podspec_file does not exist."
+    exit 1
+fi
+
+# Use sed to update the version in the podspec file
+sed -i "s/s.version\( *\)= *\"[^\"]*\"/s.version\1= \"$new_version\"/" "$podspec_file"
+
+echo "Updated version to $new_version in $podspec_file."
+
+dart_file="lib/apptentive_flutter.dart"
+
+# Check if the javascript file exists
+if [ ! -f "$dart_file" ]; then
+    echo "Error: $dart_file does not exist."
+    exit 1
+fi
+
+# Use sed to update the version in the javascript file
+sed -i "s/this.distributionVersion = \"[^\"]*\"/this.distributionVersion = \"$new_version\"/" "$dart_file"
+
+echo "Updated version to $new_version in $dart_file."

--- a/.scripts/update_ios_version.sh
+++ b/.scripts/update_ios_version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Fail on first error.
+set -e
+
+# Check for correct number of arguments.
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <podspec_filename> <new.ApptentiveKit.version>"
+    exit 1
+fi
+
+dependency_name="ApptentiveKit"
+new_version="$2"
+podspec_file="$1"
+
+# Check if the podspec file exists
+if [ ! -f "$podspec_file" ]; then
+    echo "Error: $podspec_file does not exist."
+    exit 1
+fi
+
+# Use sed to update the version in the podspec file
+sed -i "s/s.dependency '$dependency_name', '[^']*'/s.dependency '$dependency_name', '$new_version'/" "$podspec_file"
+
+echo "Updated $dependency_name to version $new_version in $podspec_file."


### PR DESCRIPTION
Steps with this PR:

1. *Manual* Determine latest distribution version, iOS dependency version, and Android dependency version
2. *Manual* Run "Update Versions" action using info from previous step
3. *Automatic* Updates distribution version everywhere it needs to be updated
4. *Automatic* Updates iOS and Android dependency versions
5. *Automatic* Adds CHANGELOG entry with new dependency versions
6. *Automatic* Opens PR from `updates/x.x.x` branch to `develop`
7. *Manual* Approve/merge update PR
8. *Manual* Open PR from `develop` to `master`
9. *Manual* Approve/merge release PR
10. *Automatic* Tag the version
11. *Automatic* Create a draft GitHub release
12. *Manual* Publish the draft release
13. *Manual* Push to `pub.dev`

Step 3 and 6 were previously automated by the `prepare_release` rake task. Steps 10 and 11 were previously automated by the `complete_release` rake task. 

I'd like to convert step 1 to be able to use arguments like `patch` and `latest` for the distribution version and native dependencies. 

I'd also like it to automatically create a release PR once `develop` is merged to from an `updates/x.x.x` branch (I'm having trouble with how the create-pull-request action expects things to be).

Lastly I'd like to automate the `pub.dev` release either as part of the complete release action or its own manual action. 
