### PR TITLE
Add publish workflow PBI-3622

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish to pub.dev
+
+on: workflow_dispatch
+#   push:
+#     tags:
+#       - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
This adds a (currently experimental and manually-run) workflow to publish the package to pub.dev. If and when we are satisfied with how this works we can consider converting it to run automatically whenever a tag is pushed (currently commented out).
