### PR TITLE
[PBI-6441]  Re-register main activity

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.apptentive:apptentive-kit-android:6.9.0'
+    implementation 'com.apptentive:apptentive-kit-android:6.9.3'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/android/src/main/kotlin/com/apptentive/apptentive_flutter/ApptentiveFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/apptentive/apptentive_flutter/ApptentiveFlutterPlugin.kt
@@ -1,7 +1,5 @@
 package com.apptentive.apptentive_flutter
 
-// TODO test push notifications
-
 import android.app.Activity
 import android.app.Application
 import apptentive.com.android.feedback.*
@@ -11,10 +9,15 @@ import apptentive.com.android.util.*
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.DefaultLifecycleObserver;
 
 
 @OptIn(InternalUseOnly::class)
@@ -69,6 +72,14 @@ class ApptentiveFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
     if (isApptentiveRegistered) {
       Apptentive.registerApptentiveActivityInfoCallback(activityInfo)
     }
+    (binding.lifecycle as HiddenLifecycleReference)
+      .lifecycle
+      .addObserver(LifecycleEventObserver { source, event ->
+        Log.v(LogTag("Flutter"), event.toString())
+        if (event == Lifecycle.Event.ON_RESUME && isApptentiveRegistered) {
+          Apptentive.registerApptentiveActivityInfoCallback(activityInfo)
+        }
+      })
   }
 
   // When re-attached to activity, set current activity context and re-register Apptentive Activity Callback


### PR DESCRIPTION
When the flutter app uses FlutterActivity, Android native SDK creates an activity to use supportFragmentManager to show the modal interactions. Once the modal interactions are dismissed, the SDK host activity is destroyed and the FlutterActivity comes to the foreground. Registering it again ensures the context is available for engaging interactions.

https://alchemer.atlassian.net/browse/PBI-6441