### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "apptentive_flutter",
+    platforms: [
+        .iOS("15.0"),
+    ],
+    products: [
+        .library(name: "apptentive-flutter", targets: ["apptentive_flutter"])
+    ],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework"),
+        .package(url: "https://github.com/apptentive/apptentive-kit-ios", from: "7.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "apptentive_flutter",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework"),
+                .product(name: "ApptentiveKit", package: "apptentive-kit-ios"),
+            ],
+            path: "Classes"
+        )
+    ]
+)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ issue_tracker: https://github.com/apptentive/apptentive-flutter/issues
 documentation: https://learn.apptentive.com/knowledge-base/apptentive-sdk-flutter-plugin-guide/
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=3.24.0"
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
The `flutter pub` process currently logs a warning about including `apptentive_flutter`, as it doesn't support Swift Package Manager. They're replacing CocoaPods with SwiftPM as it is being deprecated (going read-only in late 2026). 

This adds Swift Package Manager support to avoid this warning and ensures we can updated end-users code in the future. 