### PR TITLE
Migrate example Android build to Flutter Plugin DSL and JDK 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,13 @@ android {
     defaultConfig {
         minSdkVersion 24
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 dependencies {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "org.jetbrains.kotlin.android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,10 +21,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-//apply plugin: 'com.google.gms.google-services'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 35
@@ -46,6 +43,14 @@ android {
         }
     }
     namespace 'com.apptentive.apptentive_flutter_example'
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 configurations.all {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,17 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.21'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.7.3" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "com.google.gms.google-services" version "4.3.10" apply false
+}
+
+include ":app"


### PR DESCRIPTION
 Migrate example Android build to Flutter Plugin DSL and JDK 17                                                                                                                
                                                                                                                                                                                
  Update the example app's Gradle setup to the modern declarative                                                                                                               
  Plugin DSL and bump the toolchain for AGP 8.7 compatibility:                                                                                                                  
                                                                                                                                                                                
  - settings.gradle: replace legacy app_plugin_loader.gradle apply with                                                                                                         
    pluginManagement/plugins blocks (AGP 8.7.3, Kotlin 1.9.24)                                                                                                                  
  - app/build.gradle: use plugins {} block, drop imperative apply/flutterRoot                                                                                                   
  - build.gradle: remove obsolete buildscript classpath block                                                                                                                   
  - pin sourceCompatibility/targetCompatibility/jvmTarget to Java 17                                                                                                            
    (in both the plugin and example modules)                                                                                                                                    
  - bump Gradle wrapper 8.5 -> 8.14                                                                                                                                             
  - add android.builtInKotlin/newDsl flags from the Flutter migrator